### PR TITLE
SDL2: Fix display mode handling

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -403,6 +403,10 @@ static int SDLCALL cmpmodes(const void *A, const void *B)
         return SDL_PIXELLAYOUT(b->format) - SDL_PIXELLAYOUT(a->format);
     } else if (a->refresh_rate != b->refresh_rate) {
         return b->refresh_rate - a->refresh_rate;
+    } else if (a->driverdata != b->driverdata) {
+        // Not sure if we should compare the address directly
+        // but it's definitely better than nothing
+        return (int)((uintptr_t)b->driverdata - (uintptr_t)a->driverdata);       
     }
     return 0;
 }

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -195,7 +195,21 @@ static SDL_bool CheckXRandR(Display *display, int *major, int *minor)
 
 static int CalculateXRandRRefreshRate(const XRRModeInfo *info)
 {
-    return (info->hTotal && info->vTotal) ? SDL_round(((double)info->dotClock / (double)(info->hTotal * info->vTotal))) : 0;
+    double vTotal = info->vTotal;
+
+    if (info->modeFlags & RR_DoubleScan) {
+        /* doublescan doubles the number of lines */
+        vTotal *= 2;
+    }
+
+    if (info->modeFlags & RR_Interlace) {
+        /* interlace splits the frame into two fields */
+        /* the field rate is what is typically reported by monitors */
+        vTotal /= 2;
+    }
+
+    return (info->hTotal && info->vTotal) ? SDL_round(((double)info->dotClock / (double)(info->hTotal * vTotal))) 
+                                          : 0;
 }
 
 static SDL_bool SetXRandRModeInfo(Display *display, XRRScreenResources *res, RRCrtc crtc,


### PR DESCRIPTION
- **Refactor CalculateXRandRRefreshRate function to handle double scan and interlace modes**
- **distinguish display modes by driverdata**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved video mode comparison logic to enhance fallback mechanisms.
	- Updated refresh rate calculation to support additional display modes for X11 environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->